### PR TITLE
CUDA 11 issues

### DIFF
--- a/CUDA/inc/config.hpp.cmake
+++ b/CUDA/inc/config.hpp.cmake
@@ -31,28 +31,7 @@
 
 typedef unsigned int SizeType;
 typedef unsigned int IndType;
-
-/** \brief Combined 2-tuple (x,y) of IndType */
-typedef struct IndType2
-{
-  IndType x;
-  IndType y;
-  IndType2()
-  {
-  }
-  IndType2(IndType x, IndType y) : x(x), y(y)
-  {
-  }
-} IndType2;
-
-/** \brief Combined 3-tuple (x,y,z) of IndType */
-typedef struct IndType3
-{
-  IndType x;
-  IndType y;
-  IndType z;
-  //      IndType3(){}
-  //      IndType3(IndType x, IndType y, IndType z): x(x),y(y),z(z){}
-} IndType3;
+typedef uint2 IndType2;
+typedef uint3 IndType3;
 
 #endif  // CONFIG_H

--- a/CUDA/src/gpu/atomic/atomic_gpuNUFFT_kernels.cu
+++ b/CUDA/src/gpu/atomic/atomic_gpuNUFFT_kernels.cu
@@ -24,7 +24,7 @@ __global__ void convolutionKernel3( DType2* data,
   while (sec < N)
   {
     int ind, k, i, j;
-    int imin, imax,jmin,jmax,kmin,kmax;
+    int imin, imax, jmin, jmax, kmin, kmax;
 
     DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
@@ -141,7 +141,7 @@ __global__ void convolutionKernel3( DType2* data,
 __device__ void convolutionFunction4(int sec, int sec_max, int sec_offset, DType2* data, DType* crds, CufftType* gdata, IndType* sectors, IndType* sector_centers)
 {
     int ind, k, i, j;
-    __shared__ int max_dim, imin, imax,jmin,jmax,kmin,kmax;
+    __shared__ int max_dim, imin, imax, jmin, jmax, kmin, kmax;
 
     DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
@@ -310,8 +310,8 @@ __device__ void convolutionFunction2(int* sec, int sec_max, int sec_offset, DTyp
     __syncthreads();
 
     //start convolution
-    int ind, k, i, j, x, y, z;
-    int imin, imax,jmin,jmax,kmin,kmax;
+    int ind, x, y, z;
+    int imin, imax, jmin, jmax, kmin, kmax;
 
     DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
@@ -340,24 +340,21 @@ __device__ void convolutionFunction2(int* sec, int sec_max, int sec_offset, DTyp
       set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
       // grid this point onto its cartesian points neighbors
-      k =kmin;
-      while (k<=kmax && k>=kmin)
+      for (int k = kmin; k <= kmax; k++)
       {
         kz = mapGridToKSpace(k,GI.gridDims.z,center.z,GI.sector_offset);
         dz_sqr = (kz - data_point.z)*GI.aniso_z_scale;
         dz_sqr *= dz_sqr;
         if (dz_sqr < GI.radiusSquared)
         {
-          j=jmin;
-          while (j<=jmax && j>=jmin)
+          for (int j = jmin; j <= jmax; j++)
           {
             jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
             dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
             dy_sqr *= dy_sqr;
             if (dy_sqr < GI.radiusSquared)	
             {
-              i= imin;						
-              while (i<=imax && i>=imin)
+              for (int i = imin; i <= imax; i++)
               {
                 ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
                 dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -376,13 +373,10 @@ __device__ void convolutionFunction2(int* sec, int sec_max, int sec_offset, DTyp
                   atomicAdd(&(sdata[ind].x),val * data[data_cnt].x);
                   atomicAdd(&(sdata[ind].y),val * data[data_cnt].y);
                 } // kernel bounds check x, spherical support 
-                i++;
               } // x 	 
             } // kernel bounds check y, spherical support 
-            j++;
           } // y 
         } //kernel bounds check z 
-        k++;
       } // z
       data_cnt = data_cnt + blockDim.x;
     } //grid points per sector
@@ -486,7 +480,7 @@ __device__ void convolutionFunction2D(DType2* sdata,int* sec, int sec_max, int s
     __syncthreads();
 
     //start convolution
-    int ind, i, j, x, y;
+    int ind, x, y;
     int imin, imax,jmin,jmax;
 
     DType dx_sqr, dy_sqr, val, ix, jy;
@@ -513,16 +507,14 @@ __device__ void convolutionFunction2D(DType2* sdata,int* sec, int sec_max, int s
       set_minmax(&jy, &jmin, &jmax, GI.sector_pad_max, GI.kernel_radius);
 
       // grid this point onto its cartesian points neighbors
-      j=jmin;
-      while (j<=jmax && j>=jmin)
+      for(int  j = jmin; j <= jmax; j++)
       {
         jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
         dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
         dy_sqr *= dy_sqr;
         if (dy_sqr < GI.radiusSquared)	
         {
-          i= imin;						
-          while (i<=imax && i>=imin)
+          for(int i = imin; i <= imax; i++)
           {
             ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
             dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -543,10 +535,8 @@ __device__ void convolutionFunction2D(DType2* sdata,int* sec, int sec_max, int s
                 atomicAdd(&(sdata[ind + c * GI.sector_dim].y),val * data[data_cnt + c * GI.data_count].y);
               }
             } // kernel bounds check x, spherical support 
-            i++;
           } // x 	 
         } // kernel bounds check y, spherical support 
-        j++;
       } // y 
       data_cnt = data_cnt + blockDim.x;
     } //grid points per sector
@@ -653,7 +643,7 @@ __global__ void convolutionKernel( DType2* data,
   //start convolution
   while (sec < N)
   {
-    int ind, imin, imax, jmin, jmax,kmin,kmax, k, i, j;
+    int ind, imin, imax, jmin, jmax, kmin, kmax;
 
     DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
@@ -684,8 +674,7 @@ __global__ void convolutionKernel( DType2* data,
       set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
       // convolve neighboring cartesian points to this data point
-      k = kmin;
-      while (k<=kmax && k>=kmin)
+      for (int k = kmin; k <= kmax; k++)
       {
         kz = mapGridToKSpace(k,GI.gridDims.z,center.z,GI.sector_offset);
         dz_sqr = (kz - data_point.z)*GI.aniso_z_scale;
@@ -693,16 +682,14 @@ __global__ void convolutionKernel( DType2* data,
 
         if (dz_sqr < GI.radiusSquared)
         {
-          j=jmin;
-          while (j<=jmax && j>=jmin)
+          for (int j = jmin; j <= jmax; j++)
           {
             jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
             dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
             dy_sqr *= dy_sqr;
             if (dy_sqr < GI.radiusSquared)	
             {
-              i=imin;								
-              while (i<=imax && i>=imin)
+              for (int i = imin; i <= imax; i++)
               {
                 ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
                 dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -727,13 +714,10 @@ __global__ void convolutionKernel( DType2* data,
                   atomicAdd(&(gdata[ind].x),val * data[data_cnt].x);//Re
                   atomicAdd(&(gdata[ind].y),val * data[data_cnt].y);//Im
                 }// kernel bounds check x, spherical support 
-                i++;
               } // x loop
             } // kernel bounds check y, spherical support  
-            j++;
           } // y loop
         } //kernel bounds check z 
-        k++;
       } // z loop
       data_cnt = data_cnt + blockDim.x;
     } //data points per sector
@@ -887,7 +871,7 @@ __global__ void forwardConvolutionKernel( CufftType* data,
   //start convolution
   while (sec[threadIdx.x] < N)
   {
-    int ind, imin, imax, jmin, jmax,kmin,kmax, k, i, j;
+    int ind, imin, imax, jmin, jmax, kmin, kmax;
     DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
     __shared__ IndType3 center;
@@ -918,8 +902,7 @@ __global__ void forwardConvolutionKernel( CufftType* data,
       set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
       // convolve neighboring cartesian points to this data point
-      k = kmin;			
-      while (k<=kmax && k>=kmin)
+      for (int k = kmin; k <= kmax; k++)
       {
         kz = mapGridToKSpace(k,GI.gridDims.z,center.z,GI.sector_offset);
         dz_sqr = (kz - data_point.z)*GI.aniso_z_scale;
@@ -927,16 +910,14 @@ __global__ void forwardConvolutionKernel( CufftType* data,
 
         if (dz_sqr < GI.radiusSquared)
         {
-          j=jmin;
-          while (j<=jmax && j>=jmin)
+          for (int j = jmin; j <= jmax; j++)
           {
             jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
             dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
             dy_sqr *= dy_sqr;
             if (dy_sqr < GI.radiusSquared)	
             {
-              i=imin;								
-              while (i<=imax && i>=imin)
+              for (int i = imin; i <= imax; i++)
               {
                 ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
                 dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -963,13 +944,10 @@ __global__ void forwardConvolutionKernel( CufftType* data,
                   shared_out_data[threadIdx.x].x += gdata[ind].x * val; 
                   shared_out_data[threadIdx.x].y += gdata[ind].y * val;
                 }// kernel bounds check x, spherical support 
-                i++;
               } // x loop
             } // kernel bounds check y, spherical support  
-            j++;
           } // y loop
         } //kernel bounds check z 
-        k++;
       } // z loop
       data[data_cnt].x = shared_out_data[threadIdx.x].x;
       data[data_cnt].y = shared_out_data[threadIdx.x].y;
@@ -987,7 +965,7 @@ __global__ void forwardConvolutionKernel( CufftType* data,
 
 __device__ void forwardConvolutionFunction2(int* sec, int sec_max, int sec_offset, DType2* sdata, CufftType* gdata_cache, DType2* data, DType* crds, CufftType* gdata, IndType* sectors, IndType* sector_centers)
 {
-  int ind, imin, imax, jmin, jmax,kmin,kmax, k, i, j;
+  int ind, imin, imax, jmin, jmax, kmin, kmax, ii, jj, kk;
   DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
   __shared__ IndType3 center;
@@ -1003,16 +981,16 @@ __device__ void forwardConvolutionFunction2(int* sec, int sec_max, int sec_offse
   for (int ind=threadIdx.x; ind<GI.sector_dim; ind+=blockDim.x)
   {
     int grid_index;
-    getCoordsFromIndex(ind,&i,&j,&k,GI.sector_pad_width);
+    getCoordsFromIndex(ind,&ii,&jj,&kk,GI.sector_pad_width);
 
-    if (isOutlier(i,j,k,center.x,center.y,center.z,GI.gridDims,GI.sector_offset))
+    if (isOutlier(ii,jj,kk,center.x,center.y,center.z,GI.gridDims,GI.sector_offset))
       //calculate opposite index
-      grid_index = computeXYZ2Lin(calculateOppositeIndex(i,center.x,GI.gridDims.x,GI.sector_offset),
-      calculateOppositeIndex(j,center.y,GI.gridDims.y,GI.sector_offset),
-      calculateOppositeIndex(k,center.z,GI.gridDims.z,GI.sector_offset),
+      grid_index = computeXYZ2Lin(calculateOppositeIndex(ii,center.x,GI.gridDims.x,GI.sector_offset),
+      calculateOppositeIndex(jj,center.y,GI.gridDims.y,GI.sector_offset),
+      calculateOppositeIndex(kk,center.z,GI.gridDims.z,GI.sector_offset),
       GI.gridDims);
     else
-      grid_index = (sector_ind_offset + computeXYZ2Lin(i,j,k,GI.gridDims));
+      grid_index = (sector_ind_offset + computeXYZ2Lin(ii,jj,kk,GI.gridDims));
 
     gdata_cache[ind].x = gdata[grid_index].x;
     gdata_cache[ind].y = gdata[grid_index].y;
@@ -1039,8 +1017,7 @@ __device__ void forwardConvolutionFunction2(int* sec, int sec_max, int sec_offse
     set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
     // convolve neighboring cartesian points to this data point
-    k = kmin;
-    while (k<=kmax && k>=kmin)
+    for (int k = kmin; k <= kmax; k++)
     {
       kz = mapGridToKSpace(k,GI.gridDims.z,center.z,GI.sector_offset);
       dz_sqr = (kz - data_point.z)*GI.aniso_z_scale;
@@ -1048,16 +1025,14 @@ __device__ void forwardConvolutionFunction2(int* sec, int sec_max, int sec_offse
 
       if (dz_sqr < GI.radiusSquared)
       {
-        j=jmin;
-        while (j<=jmax && j>=jmin)
+        for (int j = jmin; j <= jmax; j++)
         {
           jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
           dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
           dy_sqr *= dy_sqr;
           if (dy_sqr < GI.radiusSquared)	
           {
-            i=imin;								
-            while (i<=imax && i>=imin)
+            for (int i = imin; i <= imax; i++)
             {
               ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
               dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -1075,13 +1050,10 @@ __device__ void forwardConvolutionFunction2(int* sec, int sec_max, int sec_offse
                 sdata[threadIdx.x].x += gdata_cache[ind].x * val; 
                 sdata[threadIdx.x].y += gdata_cache[ind].y * val;									
               }// kernel bounds check x, spherical support 
-              i++;
             } // x loop
           } // kernel bounds check y, spherical support  
-          j++;
         } // y loop
       } //kernel bounds check z 
-      k++;
     } // z loop
     atomicAdd(&(data[data_cnt].x),sdata[threadIdx.x].x);
     atomicAdd(&(data[data_cnt].y),sdata[threadIdx.x].y);
@@ -1178,7 +1150,7 @@ __global__ void forwardConvolutionKernel2D( CufftType* data,
   //start convolution
   while (sec[threadIdx.x] < N)
   {
-    int ind, imin, imax, jmin, jmax, i, j;
+    int ind, imin, imax, jmin, jmax;
     DType dx_sqr, dy_sqr, val, ix, jy;
 
     __shared__ IndType2 center;
@@ -1205,16 +1177,14 @@ __global__ void forwardConvolutionKernel2D( CufftType* data,
       set_minmax(&jy, &jmin, &jmax, GI.sector_pad_max, GI.kernel_radius);
 
       // convolve neighboring cartesian points to this data point
-      j=jmin;
-      while (j<=jmax && j>=jmin)
+      for (int j = jmin; j <= jmax; j++)
       {
         jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
         dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
         dy_sqr *= dy_sqr;
         if (dy_sqr < GI.radiusSquared)	
-        {
-          i=imin;								
-          while (i<=imax && i>=imin)
+        {			
+          for (int i = imin; i <= imax; i++)
           {
             ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
             dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -1242,10 +1212,8 @@ __global__ void forwardConvolutionKernel2D( CufftType* data,
                 shared_out_data[threadIdx.x + c * blockDim.x].y += gdata[ind+ c*GI.gridDims_count].y * val;
               }
             }// kernel bounds check x, spherical support 
-            i++;
           } // x loop
         } // kernel bounds check y, spherical support  
-        j++;
       } // y loop
 
       for (int c=threadIdx.z; c < GI.n_coils_cc; c+=blockDim.z)
@@ -1265,7 +1233,7 @@ __global__ void forwardConvolutionKernel2D( CufftType* data,
 
 __device__ void forwardConvolutionFunction2D(int* sec, int sec_max, int sec_offset, DType2* sdata, CufftType* gdata_cache, DType2* data, DType* crds, CufftType* gdata, IndType* sectors, IndType* sector_centers)
 {
-  int ind, imin, imax, jmin, jmax, i, j;
+  int ind, imin, imax, jmin, jmax, ii, jj;
   DType dx_sqr, dy_sqr, val, ix, jy;
 
   __shared__ IndType2 center;
@@ -1280,17 +1248,17 @@ __device__ void forwardConvolutionFunction2D(int* sec, int sec_max, int sec_offs
   for (int ind=threadIdx.x; ind<GI.sector_dim; ind+=blockDim.x)
   {
     int grid_index;
-    getCoordsFromIndex2D(ind,&i,&j,GI.sector_pad_width);
+    getCoordsFromIndex2D(ind,&ii,&jj,GI.sector_pad_width);
 
     // multiply data by current kernel val 
     // grid complex or scalar 
-    if (isOutlier2D(i,j,center.x,center.y,GI.gridDims.x,GI.sector_offset))
+    if (isOutlier2D(ii,jj,center.x,center.y,GI.gridDims.x,GI.sector_offset))
       //calculate opposite index
-      grid_index = getIndex2D(calculateOppositeIndex(i,center.x,GI.gridDims.x,GI.sector_offset),
-      calculateOppositeIndex(j,center.y,GI.gridDims.y,GI.sector_offset),
+      grid_index = getIndex2D(calculateOppositeIndex(ii,center.x,GI.gridDims.x,GI.sector_offset),
+      calculateOppositeIndex(jj,center.y,GI.gridDims.y,GI.sector_offset),
       GI.gridDims.x);
     else
-      grid_index = (sector_ind_offset + getIndex2D(i,j,GI.gridDims.x));
+      grid_index = (sector_ind_offset + getIndex2D(ii,jj,GI.gridDims.x));
 
     for (int c=threadIdx.z; c < GI.n_coils_cc; c+=blockDim.z)
     {
@@ -1316,16 +1284,14 @@ __device__ void forwardConvolutionFunction2D(int* sec, int sec_max, int sec_offs
     set_minmax(&jy, &jmin, &jmax, GI.sector_pad_max, GI.kernel_radius);
 
     // convolve neighboring cartesian points to this data point
-    j=jmin;
-    while (j<=jmax && j>=jmin)
+    for (int j = jmin; j <= jmax; j++)
     {
       jy = mapGridToKSpace(j,GI.gridDims.y,center.y,GI.sector_offset);
       dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
       dy_sqr *= dy_sqr;
       if (dy_sqr < GI.radiusSquared)	
-      {
-        i=imin;								
-        while (i<=imax && i>=imin)
+      {				
+        for (int i = imin; i <= imax; i++)
         {
           ix = mapGridToKSpace(i,GI.gridDims.x,center.x,GI.sector_offset);
           dx_sqr = (ix - data_point.x)*GI.aniso_x_scale;
@@ -1345,10 +1311,8 @@ __device__ void forwardConvolutionFunction2D(int* sec, int sec_max, int sec_offs
               sdata[threadIdx.x + c*blockDim.x].y += gdata_cache[ind + c*GI.sector_dim].y * val;
             }
           }// kernel bounds check x, spherical support 
-          i++;
         } // x loop
       } // kernel bounds check y, spherical support  
-      j++;
     } // y loop
 
     for (int c=threadIdx.z; c < GI.n_coils_cc; c+=blockDim.z)

--- a/CUDA/src/gpu/atomic/texture_gpuNUFFT_kernels.cu
+++ b/CUDA/src/gpu/atomic/texture_gpuNUFFT_kernels.cu
@@ -26,7 +26,7 @@ __device__ void textureConvolutionFunction(int *sec, int sec_max,
                                            IndType *sector_centers)
 {
   // start convolution
-  int ind, k, i, j, x, y, z;
+  int ind, x, y, z;
   int imin, imax, jmin, jmax, kmin, kmax;
 
   DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
@@ -60,20 +60,18 @@ __device__ void textureConvolutionFunction(int *sec, int sec_max,
     set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
     // grid this point onto its cartesian points neighbors
-    k = kmin;
-    while (k <= kmax && k >= kmin)
+    for (int k = kmin; k <= kmax; k++)
     {
       kz = mapGridToKSpace(k, GI.gridDims.z, center.z, GI.sector_offset);
       dz_sqr = (kz - data_point.z) * GI.aniso_z_scale;
       dz_sqr *= dz_sqr;
-      j = jmin;
-      while (j <= jmax && j >= jmin)
+      for (int j = jmin; j <= jmax; j++)
       {
         jy = mapGridToKSpace(j, GI.gridDims.y, center.y, GI.sector_offset);
         dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
         dy_sqr *= dy_sqr;
-        i = imin;
-        while (i <= imax && i >= imin)
+
+        for (int i = imin; i <= imax; i++)
         {
           ix = mapGridToKSpace(i, GI.gridDims.x, center.x, GI.sector_offset);
           dx_sqr = (ix - data_point.x) * GI.aniso_x_scale;
@@ -94,11 +92,8 @@ __device__ void textureConvolutionFunction(int *sec, int sec_max,
           atomicAdd(&(sdata[ind].y),
               val *
               tex1Dfetch(texDATA, data_cnt).y);
-          i++;
         }  // x
-        j++;
       }  // y
-      k++;
     }  // z
     data_cnt = data_cnt + blockDim.x;
   }  // grid points per sector
@@ -218,7 +213,7 @@ __device__ void textureConvolutionFunction2D(DType2 *sdata, int *sec,
                                              IndType *sector_centers)
 {
   // start convolution
-  int ind, i, j, x, y;
+  int ind, x, y;
   int imin, imax, jmin, jmax;
 
   DType dx_sqr, dy_sqr, val, ix, jy;
@@ -247,14 +242,13 @@ __device__ void textureConvolutionFunction2D(DType2 *sdata, int *sec,
     set_minmax(&jy, &jmin, &jmax, GI.sector_pad_max, GI.kernel_radius);
 
     // grid this point onto its cartesian points neighbors
-    j = jmin;
-    while (j <= jmax && j >= jmin)
+    for (int j = jmin; j <= jmax; j++)
     {
       jy = mapGridToKSpace(j, GI.gridDims.y, center.y, GI.sector_offset);
       dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
       dy_sqr *= dy_sqr;
-      i = imin;
-      while (i <= imax && i >= imin)
+
+      for (int i = imin; i <= imax; i++)
       {
         ix = mapGridToKSpace(i, GI.gridDims.x, center.x, GI.sector_offset);
         dx_sqr = (ix - data_point.x) * GI.aniso_x_scale;
@@ -275,9 +269,7 @@ __device__ void textureConvolutionFunction2D(DType2 *sdata, int *sec,
           atomicAdd(&(sdata[ind + c * GI.sector_dim].y),
                     val * tex1Dfetch(texDATA, data_cnt + c * GI.data_count).y);
         }
-        i++;
       }  // x
-      j++;
     }  // y
     data_cnt = data_cnt + blockDim.x;
   }  // grid points per sector
@@ -478,7 +470,7 @@ textureForwardConvolutionFunction(int *sec, int sec_max, int sec_offset,
                                   DType2 *data, DType *crds, CufftType *gdata,
                                   IndType *sectors, IndType *sector_centers)
 {
-  int ind, imin, imax, jmin, jmax, kmin, kmax, k, i, j;
+  int ind, imin, imax, jmin, jmax, kmin, kmax, ii, jj, kk;
   DType dx_sqr, dy_sqr, dz_sqr, val, ix, jy, kz;
 
   __shared__ IndType3 center;
@@ -496,18 +488,18 @@ textureForwardConvolutionFunction(int *sec, int sec_max, int sec_offset,
   for (int ind = threadIdx.x; ind < GI.sector_dim; ind += blockDim.x)
   {
     int grid_index;
-    getCoordsFromIndex(ind, &i, &j, &k, GI.sector_pad_width);
+    getCoordsFromIndex(ind, &ii, &jj, &kk, GI.sector_pad_width);
 
-    if (isOutlier(i, j, k, center.x, center.y, center.z, GI.gridDims,
+    if (isOutlier(ii, jj, kk, center.x, center.y, center.z, GI.gridDims,
                   GI.sector_offset))
       // calculate opposite index
       grid_index = computeXYZ2Lin(
-          calculateOppositeIndex(i, center.x, GI.gridDims.x, GI.sector_offset),
-          calculateOppositeIndex(j, center.y, GI.gridDims.y, GI.sector_offset),
-          calculateOppositeIndex(k, center.z, GI.gridDims.z, GI.sector_offset),
+          calculateOppositeIndex(ii, center.x, GI.gridDims.x, GI.sector_offset),
+          calculateOppositeIndex(jj, center.y, GI.gridDims.y, GI.sector_offset),
+          calculateOppositeIndex(kk, center.z, GI.gridDims.z, GI.sector_offset),
           GI.gridDims);
     else
-      grid_index = (sector_ind_offset + computeXYZ2Lin(i, j, k, GI.gridDims));
+      grid_index = (sector_ind_offset + computeXYZ2Lin(ii, jj, kk, GI.gridDims));
 
     gdata_cache[ind].x = tex1Dfetch(texGDATA, grid_index).x;
     gdata_cache[ind].y = tex1Dfetch(texGDATA, grid_index).y;
@@ -537,21 +529,19 @@ textureForwardConvolutionFunction(int *sec, int sec_max, int sec_offset,
     set_minmax(&kz, &kmin, &kmax, GI.sector_pad_max, GI.kernel_radius);
 
     // convolve neighboring cartesian points to this data point
-    k = kmin;
-    while (k <= kmax && k >= kmin)
+    for (int k = kmin; k <= kmax; k++)
     {
       kz = mapGridToKSpace(k, GI.gridDims.z, center.z, GI.sector_offset);
       dz_sqr = (kz - data_point.z) * GI.aniso_z_scale;
       dz_sqr *= dz_sqr;
 
-      j = jmin;
-      while (j <= jmax && j >= jmin)
+      for (int j = jmin; j <= jmax; j++)
       {
         jy = mapGridToKSpace(j, GI.gridDims.y, center.y, GI.sector_offset);
         dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
         dy_sqr *= dy_sqr;
-        i = imin;
-        while (i <= imax && i >= imin)
+
+        for (int i = imin; i <= imax; i++)
         {
           ix = mapGridToKSpace(i, GI.gridDims.x, center.x, GI.sector_offset);
           dx_sqr = (ix - data_point.x) * GI.aniso_x_scale;
@@ -566,12 +556,8 @@ textureForwardConvolutionFunction(int *sec, int sec_max, int sec_offset,
 
           sdata[threadIdx.x].x += gdata_cache[ind].x * val;
           sdata[threadIdx.x].y += gdata_cache[ind].y * val;
-
-          i++;
         }  // x loop
-        j++;
       }  // y loop
-      k++;
     }  // z loop
     atomicAdd(&(data[data_cnt].x), sdata[threadIdx.x].x);
     atomicAdd(&(data[data_cnt].y), sdata[threadIdx.x].y);
@@ -653,7 +639,7 @@ textureForwardConvolutionFunction2D(int *sec, int sec_max, int sec_offset,
                                     DType2 *data, DType *crds, CufftType *gdata,
                                     IndType *sectors, IndType *sector_centers)
 {
-  int ind, imin, imax, jmin, jmax, i, j;
+  int ind, imin, imax, jmin, jmax, ii, jj;
   DType val, ix, jy;
 
   __shared__ IndType2 center;
@@ -669,18 +655,18 @@ textureForwardConvolutionFunction2D(int *sec, int sec_max, int sec_offset,
   for (int ind = threadIdx.x; ind < GI.sector_dim; ind += blockDim.x)
   {
     int grid_index;
-    getCoordsFromIndex2D(ind, &i, &j, GI.sector_pad_width);
+    getCoordsFromIndex2D(ind, &ii, &jj, GI.sector_pad_width);
 
     // multiply data by current kernel val
     // grid complex or scalar
-    if (isOutlier2D(i, j, center.x, center.y, GI.gridDims, GI.sector_offset))
+    if (isOutlier2D(ii, jj, center.x, center.y, GI.gridDims, GI.sector_offset))
       // calculate opposite index
       grid_index = getIndex2D(
-          calculateOppositeIndex(i, center.x, GI.gridDims.x, GI.sector_offset),
-          calculateOppositeIndex(j, center.y, GI.gridDims.y, GI.sector_offset),
+          calculateOppositeIndex(ii, center.x, GI.gridDims.x, GI.sector_offset),
+          calculateOppositeIndex(jj, center.y, GI.gridDims.y, GI.sector_offset),
           GI.gridDims.x);
     else
-      grid_index = (sector_ind_offset + getIndex2D(i, j, GI.gridDims.x));
+      grid_index = (sector_ind_offset + getIndex2D(ii, jj, GI.gridDims.x));
 
     for (int c = 0; c < GI.n_coils_cc; c++)
     {
@@ -710,14 +696,13 @@ textureForwardConvolutionFunction2D(int *sec, int sec_max, int sec_offset,
     set_minmax(&jy, &jmin, &jmax, GI.sector_pad_max, GI.kernel_radius);
 
     // convolve neighboring cartesian points to this data point
-    j = jmin;
-    while (j <= jmax && j >= jmin)
+    for (int j = jmin; j <= jmax; j++)
     {
       jy = mapGridToKSpace(j, GI.gridDims.y, center.y, GI.sector_offset);
       DType dy_sqr = (jy - data_point.y) * GI.aniso_y_scale;
       dy_sqr *= dy_sqr;
-      i = imin;
-      while (i <= imax && i >= imin)
+
+      for (int i = imin; i <= imax; i++)
       {
         ix = mapGridToKSpace(i, GI.gridDims.x, center.x, GI.sector_offset);
         DType dx_sqr = (ix - data_point.x) * GI.aniso_x_scale;
@@ -736,9 +721,7 @@ textureForwardConvolutionFunction2D(int *sec, int sec_max, int sec_offset,
           sdata[threadIdx.x + c * blockDim.x].y +=
               gdata_cache[ind + c * GI.sector_dim].y * val;
         }
-        i++;
       }  // x loop
-      j++;
     }  // y loop
 
     for (int c = 0; c < GI.n_coils_cc; c++)
@@ -967,7 +950,6 @@ __global__ void balancedTextureForwardConvolutionKernel2D(
   CufftType *shared_out_data = (CufftType *)&shared[0];
   CufftType *gdata_cache = (CufftType *)&shared[blockDim.x * GI.n_coils_cc];
 
-  int sec_cnt = blockIdx.x;
   __shared__ int sec[THREAD_BLOCK_SIZE];
 
   // init shared memory
@@ -978,7 +960,7 @@ __global__ void balancedTextureForwardConvolutionKernel2D(
   }
   __syncthreads();
   // start convolution
-  while (sec_cnt < N)
+  for (int sec_cnt = blockIdx.x; sec_cnt < N; sec_cnt += gridDim.x)
   {
     sec[threadIdx.x] = sector_processing_order[sec_cnt].x;
     __shared__ int data_max;
@@ -991,7 +973,6 @@ __global__ void balancedTextureForwardConvolutionKernel2D(
         gdata_cache, data, crds, gdata, sectors, sector_centers);
 
     __syncthreads();
-    sec_cnt = sec_cnt + gridDim.x;
   }  // sector check
 }
 

--- a/CUDA/src/gpuNUFFT_operator_factory.cpp
+++ b/CUDA/src/gpuNUFFT_operator_factory.cpp
@@ -91,17 +91,22 @@ void gpuNUFFT::GpuNUFFTOperatorFactory::computeProcessingOrder(
   {
     if (countPerSector[i].second > 0)
     {
-      processingOrder.push_back(IndType2(countPerSector[i].first, 0));
+      IndType2 tmp;
+      tmp.x = countPerSector[i].first;
+      tmp.y = 0;
+      processingOrder.push_back(tmp);
       if (countPerSector[i].second > MAXIMUM_PAYLOAD)
       {
         int remaining = (int)countPerSector[i].second;
-        int offset = 1;
+        IndType offset = 1;
         // split sector
         while ((remaining - MAXIMUM_PAYLOAD) > 0)
         {
           remaining -= MAXIMUM_PAYLOAD;
-          processingOrder.push_back(
-              IndType2(countPerSector[i].first, (offset++) * MAXIMUM_PAYLOAD));
+          IndType2 tmp_remain;
+          tmp_remain.x = countPerSector[i].first;
+          tmp_remain.y = (offset++) * MAXIMUM_PAYLOAD;
+          processingOrder.push_back(tmp_remain);
         }
       }
     }


### PR DESCRIPTION
Setup: Ubuntu 20.04 LTS, Driver Version 510.39.01, Testing for Cuda >= 11.1
Problem description: gpuNUFFT generates wrong output as described in #89. This happens for Cuda 11.2 onwards. Unittests fail for Cuda 11.2 onwards.

After first debugging, the problem occurs in the convolution functions, where the while loops do not run correctly. Replacing the while loops by for loops solves the issue for Cuda 11.2 and unittests run through.

For Cuda >= 11.3, new issues appear: Kernels defined in `precomp_utils.hpp` via `__inline__ __device__ __host__` are not executed any more, related to compiler warnings:
```
warning: calling a __host__ function from a __host__ __device__ function is not allowed
```